### PR TITLE
feat(release): switch to per-package independent versioning and publi…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,11 +28,21 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Get Version
+      - name: Get Package from Tag
         run: |
-          TAG_NAME=${{github.event.release.tag_name}}
-          echo "PACKAGE_NAME=$(echo $TAG_NAME | cut -d "@" -f 1)" >> $GITHUB_ENV
-          echo "APP_VERSION=$(echo $TAG_NAME | cut -d "@" -f 2)" >> $GITHUB_ENV
+          TAG_NAME="${{ github.event.release.tag_name }}"
+          # Independent release tags are in the format @scope/package@version (e.g. @chimeric/core@2.0.3)
+          # Use parameter expansion to split on the last @ to handle scoped package names correctly
+          if [[ "$TAG_NAME" == @*@* ]]; then
+            PACKAGE_NAME="${TAG_NAME%@*}"
+            APP_VERSION="${TAG_NAME##*@}"
+          else
+            # Fallback for legacy v-prefixed tags (e.g. v2.0.2): publish all packages
+            PACKAGE_NAME=""
+            APP_VERSION="${TAG_NAME#v}"
+          fi
+          echo "PACKAGE_NAME=$PACKAGE_NAME" >> $GITHUB_ENV
+          echo "APP_VERSION=$APP_VERSION" >> $GITHUB_ENV
 
       - uses: pnpm/action-setup@v5
 
@@ -55,3 +65,5 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           # We need to set provenance to true in order to generate provenance statement
           NPM_CONFIG_PROVENANCE: true
+          # When set, only build and publish this specific package (derived from the release tag)
+          PROJECT_NAME: ${{ env.PACKAGE_NAME }}

--- a/nx.json
+++ b/nx.json
@@ -109,7 +109,7 @@
     }
   },
   "release": {
-    "projectsRelationship": "fixed",
+    "projectsRelationship": "independent",
     "projects": ["packages/*"],
     "git": {
       "commitMessage": "chore: updated version [no ci]"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,33 +1,44 @@
 #!/bin/bash
 
 # Script to handle the complete publishing process
-# 1. Configures git for GitHub Actions
-# 2. Builds packages
-# 3. Modifies package.json files for publishing
-# 4. Runs nx release version
-# 5. Publishes packages
+# 1. Builds packages (all, or a specific package when PROJECT_NAME is set)
+# 2. Modifies package.json files for publishing
+# 3. Publishes packages via nx release publish
+#
+# When PROJECT_NAME is set (e.g. @chimeric/core), only that package is built
+# and published. This is used by the per-package GitHub Release workflow so
+# each release triggers exactly one npm publish rather than republishing every
+# package on every release.
 
 set -e
 
 echo "Starting publish process..."
 
-# Configure git for GitHub Actions
-echo "Configuring git..."
-git config user.name github-actions
-git config user.email github-actions@github.com
+# Accept an optional project filter via env var (set by publish.yml from the release tag)
+PROJECT_NAME="${PROJECT_NAME:-}"
 
-# Build packages
-echo "Building packages..."
-pnpm build:packages
+if [ -n "$PROJECT_NAME" ]; then
+  echo "Building $PROJECT_NAME..."
+  # Build only the target project; nx respects ^build so dependencies build first
+  npx nx build "$PROJECT_NAME"
+else
+  echo "Building all packages..."
+  pnpm build:packages
+fi
 
 echo "Fixing workspace dependencies..."
-# Call the fix-workspace-deps.sh script
 ./scripts/fix-workspace-deps.sh
 
 # Publish packages (allow individual package failures for already-published versions)
 echo "Publishing packages..."
 set +e
-npx nx release publish --verbose
+if [ -n "$PROJECT_NAME" ]; then
+  echo "Publishing $PROJECT_NAME only..."
+  npx nx release publish --projects="$PROJECT_NAME" --verbose
+else
+  echo "Publishing all packages..."
+  npx nx release publish --verbose
+fi
 PUBLISH_EXIT=$?
 set -e
 
@@ -35,4 +46,4 @@ if [ $PUBLISH_EXIT -ne 0 ]; then
   echo "⚠️  Some packages may have failed to publish (e.g., already published versions). Exit code: $PUBLISH_EXIT"
 fi
 
-echo "Publish process completed successfully!" 
+echo "Publish process completed successfully!"


### PR DESCRIPTION
  ## Summary

  - **Switch `projectsRelationship` from
  `fixed` to `independent`** in `nx.json` —
  Nx now analyzes commits per-package and
  only versions/releases packages whose
  source files actually changed. Root-only
  changes (pnpm overrides, lock file
  updates, example package bumps) no longer
  trigger library releases.
  - **Fix `publish.yml` tag parsing** — the
  previous `cut -d \"@\"` approach was
  broken for scoped package names like
  `@chimeric/core@2.0.3`. Now uses bash
  parameter expansion (`\${TAG%@*}` /
  `\${TAG##*@}`) to correctly extract the
  package name and version. Falls back to
  publishing all packages for legacy
  `v`-prefixed tags or manual
  `workflow_dispatch` runs.
  - **Update `scripts/publish.sh`** to
  accept a `PROJECT_NAME` env var — when
  set, only that project is built and
  published. Each per-package GitHub Release
   now triggers exactly one targeted npm
  publish instead of republishing every
  package.