### PR TITLE
fix: remove NX Cloud to unblock CI pipeline

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -15,7 +15,6 @@
       "{workspaceRoot}/.nvmrc"
     ]
   },
-  "nxCloudId": "67d91bc583f8dd52ce0b5474",
   "plugins": [
     {
       "plugin": "@nx/js/typescript",


### PR DESCRIPTION
## Summary

- Removes `nxCloudId` from `nx.json` so NX no longer attempts to connect to NX Cloud before running tasks

The free plan limit was exhausted, causing NX Cloud to reject all CI runs with:

> _NX Cloud: Workspace is unable to be authorized. Exiting run._
> _This Nx Cloud organization has been disabled due to exceeding the FREE plan._

The `nxCloudId` field is the sole trigger for NX phoning home to the cloud service. Removing it is sufficient — no packages need to be uninstalled.

## Test plan

- [ ] Verify CI passes on this PR without the NX Cloud authorization error

🤖 Generated with [Claude Code](https://claude.com/claude-code)