### PR TITLE
revert(release): switch back to fixed monolithic releases

### DIFF
--- a/.devcontainer/.devcontainer.json
+++ b/.devcontainer/.devcontainer.json
@@ -1,0 +1,1 @@
+{"image":"mcr.microsoft.com/devcontainers/base:ubuntu"}

--- a/.devcontainer/.env.example
+++ b/.devcontainer/.env.example
@@ -1,0 +1,13 @@
+# GitHub Personal Access Token (fine-grained)
+# Create at: https://github.com/settings/personal-access-tokens/new
+# Scope it to ONLY the dataquail/chimeric repo with these permissions:
+#   - Contents: Read and write
+#   - Pull requests: Read and write
+#   - Issues: Read (optional, for reading issue context)
+#   - Metadata: Read (required, auto-selected)
+GITHUB_TOKEN=FILL_ME_IN
+
+# Claude Code authentication token
+# Get from: https://console.anthropic.com/settings/keys
+# Or use OAuth token from `claude` CLI login
+CLAUDE_CODE_OAUTH_TOKEN=FILL_ME_IN

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,72 @@
+FROM node:22
+
+ARG TZ
+ENV TZ="$TZ"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  less \
+  git \
+  procps \
+  sudo \
+  fzf \
+  zsh \
+  man-db \
+  unzip \
+  gnupg2 \
+  gh \
+  ripgrep \
+  jq \
+  nano \
+  vim \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /usr/local/share/npm-global && \
+  chown -R node:node /usr/local/share
+
+ARG USERNAME=node
+
+# Persist shell history across container rebuilds
+RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+  && mkdir /commandhistory \
+  && touch /commandhistory/.bash_history \
+  && chown -R $USERNAME /commandhistory
+
+RUN mkdir -p /workspace /home/node/.claude && \
+  chown -R node:node /workspace /home/node/.claude
+
+WORKDIR /workspace
+
+ARG GIT_DELTA_VERSION=0.18.2
+RUN ARCH=$(dpkg --print-architecture) && \
+  wget "https://github.com/dandavison/delta/releases/download/${GIT_DELTA_VERSION}/git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" && \
+  dpkg -i "git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb" && \
+  rm "git-delta_${GIT_DELTA_VERSION}_${ARCH}.deb"
+
+# Install pnpm globally
+RUN npm install -g pnpm@10.7.0
+
+USER node
+
+# Add GitHub's SSH host key so private repo clones work without prompts
+RUN mkdir -p ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts 2>/dev/null
+
+ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
+ENV PATH=/home/node/.local/bin:$PATH:/usr/local/share/npm-global/bin
+ENV SHELL=/bin/zsh
+ENV EDITOR=nano
+ENV VISUAL=nano
+
+ARG ZSH_IN_DOCKER_VERSION=1.2.0
+RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/v${ZSH_IN_DOCKER_VERSION}/zsh-in-docker.sh)" -- \
+  -p git \
+  -p fzf \
+  -a "source /usr/share/doc/fzf/examples/key-bindings.zsh" \
+  -a "source /usr/share/doc/fzf/examples/completion.zsh" \
+  -a "export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+  -x
+
+RUN echo 'export PATH="/home/node/.local/bin:$PATH"' >> ~/.zshrc && \
+  curl -fsSL https://claude.ai/install.sh | bash
+
+# Post-create script to seed Claude config after volumes are mounted
+COPY --chown=node:node post_create.sh /usr/local/bin/post_create.sh

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+{
+  "name": "Claude Code Agent - Chimeric",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "devcontainer",
+  "remoteUser": "node",
+  "containerEnv": {
+    "CLAUDE_CONFIG_DIR": "/home/node/.claude",
+    "DEVCONTAINER": "true"
+  },
+  "workspaceFolder": "/workspace",
+  "postCreateCommand": "bash /usr/local/bin/post_create.sh"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,22 @@
+services:
+  devcontainer:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        TZ: ${TZ:-America/Los_Angeles}
+        GIT_DELTA_VERSION: 0.18.2
+        ZSH_IN_DOCKER_VERSION: 1.2.0
+    volumes:
+      - claude-code-bashhistory:/commandhistory
+      - claude-code-config:/home/node/.claude
+    command: sleep infinity
+    env_file:
+      - .env
+    environment:
+      CLAUDE_CONFIG_DIR: /home/node/.claude
+      DEVCONTAINER: "true"
+
+volumes:
+  claude-code-bashhistory:
+  claude-code-config:

--- a/.devcontainer/post_create.sh
+++ b/.devcontainer/post_create.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Skip Claude Code onboarding when using CLAUDE_CODE_OAUTH_TOKEN
+echo '{"hasCompletedOnboarding":true,"installMethod":"native"}' > /home/node/.claude/.claude.json
+
+# Clone the chimeric repo
+git clone https://${GITHUB_TOKEN}@github.com/dataquail/chimeric.git /workspace/chimeric
+
+# Install dependencies
+cd /workspace/chimeric
+pnpm install
+
+# Build all packages so everything is ready
+pnpm run build:all

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,21 +28,11 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Get Package from Tag
+      - name: Get Version
         run: |
-          TAG_NAME="${{ github.event.release.tag_name }}"
-          # Independent release tags are in the format @scope/package@version (e.g. @chimeric/core@2.0.3)
-          # Use parameter expansion to split on the last @ to handle scoped package names correctly
-          if [[ "$TAG_NAME" == @*@* ]]; then
-            PACKAGE_NAME="${TAG_NAME%@*}"
-            APP_VERSION="${TAG_NAME##*@}"
-          else
-            # Fallback for legacy v-prefixed tags (e.g. v2.0.2): publish all packages
-            PACKAGE_NAME=""
-            APP_VERSION="${TAG_NAME#v}"
-          fi
-          echo "PACKAGE_NAME=$PACKAGE_NAME" >> $GITHUB_ENV
-          echo "APP_VERSION=$APP_VERSION" >> $GITHUB_ENV
+          TAG_NAME=${{github.event.release.tag_name}}
+          echo "PACKAGE_NAME=$(echo $TAG_NAME | cut -d "@" -f 1)" >> $GITHUB_ENV
+          echo "APP_VERSION=$(echo $TAG_NAME | cut -d "@" -f 2)" >> $GITHUB_ENV
 
       - uses: pnpm/action-setup@v5
 
@@ -65,5 +55,3 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           # We need to set provenance to true in order to generate provenance statement
           NPM_CONFIG_PROVENANCE: true
-          # When set, only build and publish this specific package (derived from the release tag)
-          PROJECT_NAME: ${{ env.PACKAGE_NAME }}

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ website/dist
 /docs/scratch
 .claude/worktrees
 .claude/settings.local.json
+
+#DevPod
+.devcontainer/.env

--- a/nx.json
+++ b/nx.json
@@ -108,7 +108,7 @@
     }
   },
   "release": {
-    "projectsRelationship": "independent",
+    "projectsRelationship": "fixed",
     "projects": ["packages/*"],
     "git": {
       "commitMessage": "chore: updated version [no ci]"

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,44 +1,33 @@
 #!/bin/bash
 
 # Script to handle the complete publishing process
-# 1. Builds packages (all, or a specific package when PROJECT_NAME is set)
-# 2. Modifies package.json files for publishing
-# 3. Publishes packages via nx release publish
-#
-# When PROJECT_NAME is set (e.g. @chimeric/core), only that package is built
-# and published. This is used by the per-package GitHub Release workflow so
-# each release triggers exactly one npm publish rather than republishing every
-# package on every release.
+# 1. Configures git for GitHub Actions
+# 2. Builds packages
+# 3. Modifies package.json files for publishing
+# 4. Runs nx release version
+# 5. Publishes packages
 
 set -e
 
 echo "Starting publish process..."
 
-# Accept an optional project filter via env var (set by publish.yml from the release tag)
-PROJECT_NAME="${PROJECT_NAME:-}"
+# Configure git for GitHub Actions
+echo "Configuring git..."
+git config user.name github-actions
+git config user.email github-actions@github.com
 
-if [ -n "$PROJECT_NAME" ]; then
-  echo "Building $PROJECT_NAME..."
-  # Build only the target project; nx respects ^build so dependencies build first
-  npx nx build "$PROJECT_NAME"
-else
-  echo "Building all packages..."
-  pnpm build:packages
-fi
+# Build packages
+echo "Building packages..."
+pnpm build:packages
 
 echo "Fixing workspace dependencies..."
+# Call the fix-workspace-deps.sh script
 ./scripts/fix-workspace-deps.sh
 
 # Publish packages (allow individual package failures for already-published versions)
 echo "Publishing packages..."
 set +e
-if [ -n "$PROJECT_NAME" ]; then
-  echo "Publishing $PROJECT_NAME only..."
-  npx nx release publish --projects="$PROJECT_NAME" --verbose
-else
-  echo "Publishing all packages..."
-  npx nx release publish --verbose
-fi
+npx nx release publish --verbose
 PUBLISH_EXIT=$?
 set -e
 


### PR DESCRIPTION
## Summary

- Reverts #76 which switched to independent per-package releases
- Restores fixed/monolithic versioning where all packages share the same version
- With only 4 tightly-coupled packages sharing the same release cadence, fixed versioning is simpler and avoids the per-project tag bootstrapping issues that independent releases require

## Test plan

- [x] `npx nx release --dry-run` passes and correctly resolves versions from existing `v2.0.3` tag
- [ ] CI pipeline passes on this PR
- [ ] Next release on main creates a single `v{version}` tag and bumps all packages together